### PR TITLE
Rename espresso dts

### DIFF
--- a/arch/arm/boot/dts/omap4-samsung-espresso3g.dts
+++ b/arch/arm/boot/dts/omap4-samsung-espresso3g.dts
@@ -4,7 +4,7 @@
 
 / {
 	model = "Samsung Galaxy Tab 2 3g 7-inch";
-	compatible = "samsung,espresso73g", "ti,omap4430", "ti,omap4";
+	compatible = "samsung,espresso3g", "ti,omap4430", "ti,omap4";
 	
 	memory@80000000 {
 		device_type = "memory";

--- a/arch/arm/boot/dts/omap4-samsung-espressowifi.dts
+++ b/arch/arm/boot/dts/omap4-samsung-espressowifi.dts
@@ -4,7 +4,7 @@
 
 / {
 	model = "Samsung Galaxy Tab 2 Wifi 7-inch";
-	compatible = "samsung,espresso7wifi", "ti,omap4430", "ti,omap4";
+	compatible = "samsung,espressowifi", "ti,omap4430", "ti,omap4";
 	
 	memory@80000000 {
 		device_type = "memory";


### PR DESCRIPTION
We should drop  `espresso7` names in dts. Let's put `espressowifi` and `espresso3g` in both of them.<br/>
This way, we make sure to have the exact codename of both of the devices.