### PR TITLE
Fix twl6030-power typo and add UART3 support

### DIFF
--- a/arch/arm/boot/dts/omap4-samsung-espresso.dts
+++ b/arch/arm/boot/dts/omap4-samsung-espresso.dts
@@ -435,6 +435,13 @@
 		>;
 	};
 
+	uart3_pins: pinmux_uart3_pins {
+		pinctrl-single,pins = <
+			OMAP4_IOPAD(0x144, PIN_INPUT | MUX_MODE0)		/* uart3_rx_irrx */
+			OMAP4_IOPAD(0x146, PIN_OUTPUT | MUX_MODE0)		/* uart3_tx_irtx */
+		>;
+	};
+
 	uart2_pins: pinmux_uart2_pins {
 		pinctrl-single,pins = <
 			OMAP4_IOPAD(0x118, PIN_INPUT_PULLUP | MUX_MODE0)	/* uart2_cts.uart2_cts */
@@ -482,6 +489,14 @@
 			OMAP4_IOPAD(0x058, PIN_INPUT | MUX_MODE3)
 		>;
 	};*/
+};
+
+&uart3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart3_pins>;
+
+	interrupts-extended = <&wakeupgen GIC_SPI 74 IRQ_TYPE_LEVEL_HIGH
+			       &omap4_pmx_core OMAP4_UART3_RX>;
 };
 
 &i2c1 {

--- a/drivers/mfd/twl6030-power.c
+++ b/drivers/mfd/twl6030-power.c
@@ -66,7 +66,7 @@ MODULE_DEVICE_TABLE(of, twl6030_power_of_match);
 
 static int twl6030_power_probe(struct platform_device *pdev)
 {
-	const struct twl4030x_power_data *pdata = dev_get_platdata(&pdev->dev);
+	const struct twl4030_power_data *pdata = dev_get_platdata(&pdev->dev);
 	struct device_node *node = pdev->dev.of_node;
 
 	if (!pdata && !node) {


### PR DESCRIPTION
Enables serial debugging on galaxy tab 2